### PR TITLE
Using LinkedHashMap instead of HashMap

### DIFF
--- a/src/main/java/de/crunc/jackson/datatype/vertx/JsonObjectBuilder.java
+++ b/src/main/java/de/crunc/jackson/datatype/vertx/JsonObjectBuilder.java
@@ -4,7 +4,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import javax.annotation.Nullable;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -18,7 +18,7 @@ public class JsonObjectBuilder {
     private final Map<String, Object> values;
 
     private JsonObjectBuilder() {
-        values = new HashMap<String, Object>();
+        values = new LinkedHashMap<String, Object>();
     }
 
     /**


### PR DESCRIPTION
Some times need to preserve the insertion order. For example vertx uses LinkedHashMap for preserve insertion order https://github.com/bdecoste/vert.x/blob/master/vertx-core/src/main/java/org/vertx/java/core/json/JsonObject.java#L50
